### PR TITLE
Use config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
-tests 
+test/test_data
  ## sample data for tests
 
 # Complexity

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.py[cod]
 
+data
+
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,73 @@ To install, clone the repo & edit the default values:
     $ vim query_tcga/query_tcga/defaults.py
     $ python setup.py install
     
+Or, install from git via pip:
+    
+    $ pip install git+git://github.com/jburos/query_tcga
+
+Setup
+-----
+
+There are a few steps you will have to follow before using this code. 
+   - Install [gdc-client](https://github.com/NCI-GDC/gdc-client). 
+       - Install per the [instructions](https://gdc-docs.nci.nih.gov/Data_Transfer_Tool/Users_Guide/Getting_Started/#downloading-the-gdc-data-transfer-tool)
+       - Edit the variable `GDC_CLIENT_PATH` by one of the methods described below
+   - Log into GDC, request access to TCGA & download an auth-token 
+      1. Gain [authorization](https://gdc-docs.nci.nih.gov/API/Users_Guide/Authentication_and_Authorization/)
+      2. Download the [authentication token](https://gdc-portal.nci.nih.gov/)
+      3. Edit the variable `GDC_TOKEN_PATH` by one of the methods described below
+
+Once you have these items set up, you can use this package to download and/or parse clinical, WXS, VCF and other files from the GDC portal by project. 
+
+
+Configuration
+-------------
+
+Because many of the files available via the GDC require authentication, some configuration settings are required in order to use this package.
+
+Only one setting is required to be set by the user: `GDC_TOKEN_PATH`. The other setting (`GDC_CLIENT_PATH`) is strongly recommended.
+
+These and all settings can be configured in one of two ways:
+
+1. Via a `config.ini` file, loaded in via `config.load_config()`
+2. In Python code, updating value via `config.set_value()`
+
+If you choose to use a config file, options should be included under `[main]`, like so:
+
+**Example `config.ini` file **
+```
+[main]
+GDC_TOKEN_PATH = /full/path/to/your/gdc_token_file.txt
+GDC_CLIENT_PATH = /usr/local/bin/gdc-client
+```
+
+This can be loaded into a python script as:
+
+```
+from query_tcga import config
+
+config.load_config('config.ini')
+```
+
+Example
+-------
+
+See the companion repo ([tcga-blca](http://github.com/jburos/tcga-blca)) for example usage.
+
+
 Contributing
 ------------
 
 TBD
 
-Example
--------
 
-TBD
+Testing
+--------
+
+Test cases for query_tcga are written in [pytest](http://docs.pytest.org/en/latest/). 
+
+For example, you can run test cases as follows:
+
+```
+python -m pytest tests --exitfirst -v
+```

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,29 @@
+# tcga-blca
+
+Example using [Cohorts](http://github.com/hammerlab/cohorts) to manage TCGA-BLCA for analysis
+
+1. Query GDC for clinical and sample datasets for TCGA-BLCA data (query code to be merged into [pygdc](http://github.com/arahuja/pygdc))
+2. Set up a Cohort using [Cohorts](http://github.com/hammerlab/cohorts) to manage these data
+
+# Setup 
+
+There are two items which you will want to configure before using this code. 
+   - [gdc-client](https://github.com/NCI-GDC/gdc-client). 
+       - Install per the [instructions](https://gdc-docs.nci.nih.gov/Data_Transfer_Tool/Users_Guide/Getting_Started/#downloading-the-gdc-data-transfer-tool)
+       - Edit the variable `GDC_CLIENT_PATH` in `query_tcga/defaults.py`
+   - auth-token, because many files are controlled-access. 
+      1. Gain [authorization](https://gdc-docs.nci.nih.gov/API/Users_Guide/Authentication_and_Authorization/)
+      2. Download the [authentication token](https://gdc-portal.nci.nih.gov/)
+      3. Edit the variable `GDC_TOKEN_PATH` in `query_tcga/defaults.py`
+
+Once you have those two items set up, you can run one or both of the `refresh_*.py` scripts to fetch data from the GDC portal.
+
+# Testing
+
+Test cases are written in [pytest](http://docs.pytest.org/en/latest/). 
+
+For example, you can run test cases as follows:
+
+```
+python -m pytest tests --exitfirst -v
+```

--- a/query_tcga/api.py
+++ b/query_tcga/api.py
@@ -48,6 +48,7 @@ def get_data(endpoint_name, arg=None,
                                              )
 
     # requests URL-encodes automatically
+    log.info('submitting request for {endpoint} with params {params}'.format(endpoint=endpoint, params=params))
     response = requests_get(endpoint, params=params)
     response.raise_for_status()
     return response

--- a/query_tcga/api.py
+++ b/query_tcga/api.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import
 import pandas as pd
-import io
 import logging
 from .log_with import log_with
-from . import defaults 
-from .defaults import GDC_API_ENDPOINT
+from .config import get_setting_value 
 from . import parameters as _params
 from .cache import requests_get
 from . import helpers
@@ -17,14 +15,14 @@ log.setLevel(logging.DEBUG)
 
 @log_with()
 def get_data(endpoint_name, arg=None,
-              project_name=None, fields=None, size=defaults.DEFAULT_SIZE, page=0,
+              project_name=None, fields=None, size=get_setting_value('DEFAULT_SIZE'), page=0,
               data_category=None, query_args={}, verify=False, *args, **kwargs):
     """ Get single result from querying GDC api endpoint
 
     >>> file = get_data(endpoint='files', data_category='Clinical', query_args=dict(file_id=df['case_uuid'][0]))
     <Response [200]>
     """
-    endpoint = GDC_API_ENDPOINT.format(endpoint=endpoint_name)
+    endpoint = get_setting_value('GDC_API_ENDPOINT').format(endpoint=endpoint_name)
     if arg:
         endpoint = endpoint+'/{}'.format(arg)
     else:
@@ -57,7 +55,7 @@ def get_data(endpoint_name, arg=None,
 
 @log_with()
 def _get_case_data(arg=None,
-              project_name=None, fields=None, size=defaults.DEFAULT_SIZE, page=1,
+              project_name=None, fields=None, size=get_setting_value('DEFAULT_SIZE'), page=1,
               data_category=None, query_args={}, verify=False, **kwargs):
     """ Get single case json matching project_name & categories
 
@@ -75,7 +73,7 @@ def _get_sample_data():
 
 
 @log_with()
-def get_fileinfo(file_id, fields=defaults.DEFAULT_FILE_FIELDS, format=None):
+def get_fileinfo(file_id, fields=get_setting_value('DEFAULT_FILE_FIELDS'), format=None):
     query_args = {'files.file_id': file_id}
     response = get_data(endpoint_name='files', query_args=query_args, fields=fields, format=format)
     if format == 'json':
@@ -84,7 +82,10 @@ def get_fileinfo(file_id, fields=defaults.DEFAULT_FILE_FIELDS, format=None):
         return response
 
 
-def get_fileinfo_data(file_id, fields=defaults.DEFAULT_FILE_FIELDS, chunk_size=defaults.DEFAULT_CHUNK_SIZE):
+def get_fileinfo_data(file_id,
+                      fields=get_setting_value('DEFAULT_FILE_FIELDS'),
+                      chunk_size=get_setting_value('DEFAULT_CHUNK_SIZE')
+                      ):
     file_id = helpers.convert_to_list(file_id)
     if len(file_id)>chunk_size:
         chunks = [file_id[x:x+chunk_size] for x in range(0, len(file_id), chunk_size)]

--- a/query_tcga/api.py
+++ b/query_tcga/api.py
@@ -50,6 +50,7 @@ def get_data(endpoint_name, arg=None,
     # requests URL-encodes automatically
     log.info('submitting request for {endpoint} with params {params}'.format(endpoint=endpoint, params=params))
     response = requests_get(endpoint, params=params)
+    log.info('url requested was: {}'.format(response.url))
     response.raise_for_status()
     return response
 

--- a/query_tcga/cache.py
+++ b/query_tcga/cache.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from .defaults import USE_CACHE
 import requests
 import time
-from socket import error as SocketError
 import errno
 import logging
 
@@ -40,4 +39,19 @@ def requests_get(*args, **kwargs):
             logging.warning('Warning - connection reset by peer. Trying request again.')
             time.sleep(12)
             resp = requests.get(*args, **kwargs)
+    return resp
+
+
+@RateLimited(1)
+def requests_post(*args, **kwargs):
+    time.sleep(10)
+    try:
+        resp = requests.post(*args, **kwargs)
+    except requests.ConnectionError as e:
+        if e.errno != errno.ECONNRESET:
+            raise # Not error we are looking for
+        else:
+            logging.warning('Warning - connection reset by peer. Trying request again.')
+            time.sleep(12)
+            resp = requests.post(*args, **kwargs)
     return resp

--- a/query_tcga/cache.py
+++ b/query_tcga/cache.py
@@ -30,10 +30,10 @@ def setup_cache():
 
 @RateLimited(1)
 def requests_get(*args, **kwargs):
-    time.sleep(2)
+    time.sleep(10)
     try:
         resp = requests.get(*args, **kwargs)
-    except SocketError as e:
+    except requests.ConnectionError as e:
         if e.errno != errno.ECONNRESET:
             raise # Not error we are looking for
         else:

--- a/query_tcga/cache.py
+++ b/query_tcga/cache.py
@@ -40,7 +40,7 @@ def requests_get(*args, **kwargs):
     global SESSION
     time.sleep(10)
     try:
-        resp = SESSION.get(*args, timeout=5, **kwargs)
+        resp = SESSION.get(*args, **kwargs)
     except requests.ConnectionError as e:
         if e.errno != 54:
             raise # Not error we are looking for

--- a/query_tcga/cache.py
+++ b/query_tcga/cache.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
-from .defaults import USE_CACHE
+from .config import get_setting_value
 import requests
 import time
 import errno
 import logging
+
+SESSION = requests.Session()
 
 def RateLimited(maxPerSecond):
     minInterval = 1.0 / float(maxPerSecond)
@@ -22,29 +24,36 @@ def RateLimited(maxPerSecond):
 
 
 def setup_cache():
-    if USE_CACHE:
+    global SESSION
+    if get_setting_value('USE_CACHE'):
         import requests_cache
-        requests_cache.install_cache(cache_name='github_cache', backend='sqlite', expire_after=180)
+        requests_cache.install_cache(cache_name='gdc_cache', backend='sqlite', expire_after=18000)
+    #   import cachecontrol
+    #   from cachecontrol.caches import FileCache
+    #   SESSION = cachecontrol.CacheControl(requests.Session(), cache=FileCache('.web_cache', forever=True))
+    #else:
+    #    SESSION = requests.Session()
 
 
 @RateLimited(1)
 def requests_get(*args, **kwargs):
+    global SESSION
     time.sleep(10)
     try:
-        resp = requests.get(*args, **kwargs)
+        resp = SESSION.get(*args, timeout=5, **kwargs)
     except requests.ConnectionError as e:
-        if e.errno != errno.ECONNRESET:
+        if e.errno != 54:
             raise # Not error we are looking for
         else:
             logging.warning('Warning - connection reset by peer. Trying request again.')
             time.sleep(12)
-            resp = requests.get(*args, **kwargs)
+            resp = SESSION.get(*args, **kwargs)
     return resp
 
 
 @RateLimited(1)
 def requests_post(*args, **kwargs):
-    time.sleep(10)
+    time.sleep(1)
     try:
         resp = requests.post(*args, **kwargs)
     except requests.ConnectionError as e:
@@ -55,3 +64,7 @@ def requests_post(*args, **kwargs):
             time.sleep(12)
             resp = requests.post(*args, **kwargs)
     return resp
+
+
+if get_setting_value('USE_CACHE'):
+    setup_cache()

--- a/query_tcga/cache.py
+++ b/query_tcga/cache.py
@@ -20,11 +20,13 @@ def RateLimited(maxPerSecond):
 
 
 def setup_cache():
-	if USE_CACHE:
-		import requests_cache
-		requests_cache.install_cache(cache_name='github_cache', backend='sqlite', expire_after=180)
+    if USE_CACHE:
+        import requests_cache
+        requests_cache.install_cache(cache_name='github_cache', backend='sqlite', expire_after=180)
 
 
-@RateLimited(2)
+@RateLimited(1)
 def requests_get(*args, **kwargs):
-	return requests.get(*args, **kwargs)
+    time.sleep(2)
+    resp = requests.get(*args, **kwargs)
+    return resp

--- a/query_tcga/cohort.py
+++ b/query_tcga/cohort.py
@@ -72,32 +72,37 @@ def _merge_filepath_with_fileinfo(files):
     return pd.merge(fileinfo, filepath_data, on='file_id')
 
 
-def prep_cohort_patients(project_name, include_vcfs=True, n=None, **kwargs):
+def prep_cohort_patients(project_name, include_vcfs=True, n=None, vcf_fileinfo=None, **kwargs):
     """ Given a project_name, return a list of cohorts.Patient objects
     """
     clin = qt.get_clinical_data(project_name=project_name, n=n, **kwargs)
-    vcf_fileinfo = None
     if not n and include_vcfs:
-        all_vcf_files = samples.download_vcf_files(project_name=project_name, **kwargs)
-        vcf_fileinfo = _merge_filepath_with_fileinfo(all_vcf_files)
+        if vcf_fileinfo is None:
+            all_vcf_files = samples.download_vcf_files(project_name=project_name, **kwargs)
+            vcf_fileinfo = _merge_filepath_with_fileinfo(all_vcf_files)
+        else:
+            vcf_fileinfo = _merge_filepath_with_fileinfo(all_vcf_files) 
     patients = []
     for (i, row) in clin.iterrows():
-        if include_vcfs:
-            if vcf_fileinfo is None:
+        if include_vcfs and vcf_fileinfo is None:
                 try:
                     vcf_files = samples.download_vcf_files(query_args={'cases.case_id': row['case_id']},
-                     project_name=project_name)
+                                                           project_name=project_name)
                 except:
                     logging.warning('No VCF file found for case: {}'.format(row['case_id']))
                     patients.append(prep_patient_data(row))
-                finally:
+                else:
                     patients.append(prep_patient_data(row, snv_vcf_paths=vcf_files))
-            else:
+        elif include_vcfs:
                 vcf_files = vcf_fileinfo.loc[vcf_fileinfo['case_id']==row['case_id'], 'file_path']
-                patients.append(prep_patient_data(row, snv_vcf_paths=vcf_files))
+                if len(vcf_files)>0:
+                    patients.append(prep_patient_data(row, snv_vcf_paths=vcf_files))
+                else:
+                    patients.append(prep_patient_data(row))
         else:
             patients.append(prep_patient_data(row))
     return patients
+
 
 def prep_cohort(patients, cache_dir='data-cache', **kwargs):
     """ Given a list of patients, create a `cohorts.Cohort`

--- a/query_tcga/cohort.py
+++ b/query_tcga/cohort.py
@@ -5,6 +5,7 @@ from . import samples
 from . import helpers
 import numpy as np
 import pandas as pd
+import logging
 
 def prep_patient_data(row, snv_vcf_paths=None, **kwargs):
     patient_id = row['case_id']
@@ -71,8 +72,6 @@ def _merge_filepath_with_fileinfo(files):
     return pd.merge(fileinfo, filepath_data, on='file_id')
 
 
-
-
 def prep_cohort_patients(project_name, include_vcfs=True, n=None, **kwargs):
     """ Given a project_name, return a list of cohorts.Patient objects
     """
@@ -85,10 +84,17 @@ def prep_cohort_patients(project_name, include_vcfs=True, n=None, **kwargs):
     for (i, row) in clin.iterrows():
         if include_vcfs:
             if vcf_fileinfo is None:
-                vcf_files = samples.download_vcf_files(query_args={'cases.case_id': row['case_id']}, project_name=project_name)
+                try:
+                    vcf_files = samples.download_vcf_files(query_args={'cases.case_id': row['case_id']},
+                     project_name=project_name)
+                except:
+                    logging.warning('No VCF file found for case: {}'.format(row['case_id']))
+                    patients.append(prep_patient_data(row))
+                finally:
+                    patients.append(prep_patient_data(row, snv_vcf_paths=vcf_files))
             else:
                 vcf_files = vcf_fileinfo.loc[vcf_fileinfo['case_id']==row['case_id'], 'file_path']
-            patients.append(prep_patient_data(row, snv_vcf_paths=vcf_files))
+                patients.append(prep_patient_data(row, snv_vcf_paths=vcf_files))
         else:
             patients.append(prep_patient_data(row))
     return patients

--- a/query_tcga/cohort.py
+++ b/query_tcga/cohort.py
@@ -72,16 +72,15 @@ def _merge_filepath_with_fileinfo(files):
     return pd.merge(fileinfo, filepath_data, on='file_id')
 
 
-def prep_cohort_patients(project_name, include_vcfs=True, n=None, vcf_fileinfo=None, **kwargs):
+def prep_cohort_patients(project_name, include_vcfs=True, n=None, all_vcfs=None, **kwargs):
     """ Given a project_name, return a list of cohorts.Patient objects
     """
     clin = qt.get_clinical_data(project_name=project_name, n=n, **kwargs)
+    vcf_fileinfo = None
     if not n and include_vcfs:
-        if vcf_fileinfo is None:
-            all_vcf_files = samples.download_vcf_files(project_name=project_name, **kwargs)
-            vcf_fileinfo = _merge_filepath_with_fileinfo(all_vcf_files)
-        else:
-            vcf_fileinfo = _merge_filepath_with_fileinfo(all_vcf_files) 
+        if all_vcfs is None:
+            all_vcfs = samples.download_vcf_files(project_name=project_name, **kwargs)
+        vcf_fileinfo = _merge_filepath_with_fileinfo(all_vcf_files)
     patients = []
     for (i, row) in clin.iterrows():
         if include_vcfs and vcf_fileinfo is None:

--- a/query_tcga/config.py
+++ b/query_tcga/config.py
@@ -50,7 +50,7 @@ def load_config(config_file='~/.query_tcga.ini'):
     config.read(config_file)
     if not config.has_section('main'):
         raise ValueError('Config file {} has no section "main"'.format(config_file))
-    for (key, val) in config['main'].items():
+    for (key, val) in config.items('main'):
         _set_value(key.upper(), val)
     return
 

--- a/query_tcga/config.py
+++ b/query_tcga/config.py
@@ -48,13 +48,18 @@ def load_config(config_file = 'config.ini'):
     config = SafeConfigParser(allow_no_value=True)
     config.read(config_file)
     for (key, val) in config.getitems():
-        set_setting_value(key, val)
+        _set_value(key, val)
 
 
-def set_setting_value(setting_name, value):
+def _set_value(setting_name, value):
     global __DEFAULTS
     setattr(__DEFAULTS, setting_name, value)
     logging.info('Setting {name} = {value}'.format(name=setting_name, value=value))
+
+
+def set_value(**kwargs):
+    for (key, val) in dict(**kwargs).getitems():
+        _set_value(key, val)
 
 
 def get_setting_value(setting_name):

--- a/query_tcga/config.py
+++ b/query_tcga/config.py
@@ -58,8 +58,9 @@ def _set_value(setting_name, value):
 
 
 def set_value(**kwargs):
-    for (key, val) in dict(**kwargs).getitems():
-        _set_value(key, val)
+    args = dict(**kwargs)
+    for key in args:
+        _set_value(key, args[key])
 
 
 def get_setting_value(setting_name):

--- a/query_tcga/config.py
+++ b/query_tcga/config.py
@@ -1,4 +1,4 @@
-from ConfigParser import SafeConfigParser
+#from ConfigParser import SafeConfigParser
 from . import defaults
 import os
 import logging
@@ -41,11 +41,12 @@ def restore_default_settings():
 def load_config(config_file = 'config.ini'):
     """ Load config file into default settings
     """
+    raise ValueError('module not yet implemented')
     if not os.path.exists(config_file):
         logging.warning('Config file does not exist: {}. Using default settings.'.format(config_file))
         return False
     ## get user-level config in *.ini format
-    config = SafeConfigParser(allow_no_value=True)
+    #config = SafeConfigParser(allow_no_value=True)
     config.read(config_file)
     for (key, val) in config.getitems():
         _set_value(key, val)

--- a/query_tcga/config.py
+++ b/query_tcga/config.py
@@ -2,6 +2,7 @@
 from . import defaults
 import os
 import logging
+import configparser
 
 ## empty class to hold "current" settings
 class Settings:
@@ -38,18 +39,20 @@ def restore_default_settings():
     logging.info('Settings reverted to their default values.')
 
 
-def load_config(config_file = 'config.ini'):
+def load_config(config_file='~/.query_tcga.ini'):
     """ Load config file into default settings
     """
-    raise ValueError('module not yet implemented')
     if not os.path.exists(config_file):
         logging.warning('Config file does not exist: {}. Using default settings.'.format(config_file))
-        return False
+        return
     ## get user-level config in *.ini format
-    #config = SafeConfigParser(allow_no_value=True)
+    config = configparser.ConfigParser()
     config.read(config_file)
-    for (key, val) in config.getitems():
-        _set_value(key, val)
+    if not config.has_section('main'):
+        raise ValueError('Config file {} has no section "main"'.format(config_file))
+    for (key, val) in config['main'].items():
+        _set_value(key.upper(), val)
+    return
 
 
 def _set_value(setting_name, value):

--- a/query_tcga/configure.py
+++ b/query_tcga/configure.py
@@ -1,0 +1,28 @@
+from simple_settings import settings
+from . import defaults
+
+## load default settings if not already defined
+default_settings = dict(
+	USE_CACHE=defaults.USE_CACHE, 
+	#GDC_TOKEN_PATH=defaults.GDC_TOKEN_PATH,
+	GDC_CLIENT_PATH=defaults.GDC_CLIENT_PATH,
+	GDC_API_ENDPOINT=defaults.GDC_API_ENDPOINT,
+	GDC_DATA_DIR=defaults.GDC_DATA_DIR,
+	# these are used since you cannot query them
+	VALID_ENDPOINTS=defaults.VALID_ENDPOINTS,
+	# number of records per page, by default
+	DEFAULT_SIZE=defaults.DEFAULT_SIZE,
+	# fields to pull for 'file-metadata' table
+	DEFAULT_FILE_FIELDS=defaults.DEFAULT_FILE_FIELDS,
+	DEFAULT_CHUNK_SIZE=defaults.DEFAULT_CHUNK_SIZE,
+	)
+
+def get_setting_value(setting_name, default_settings = default_settings, user_settings = settings.as_dict()):
+	## use user-level setting if defined 
+	if setting_name in user_settings:
+		return user_settings[setting_name]
+	## otherwise, use default value if defined
+	elif setting_name in default_settings:
+		return default_settings[setting_name]
+	else:
+		raise ValueError('Setting {setting_name} was not provided & is required.'.format(setting_name=setting_name))

--- a/query_tcga/defaults.py
+++ b/query_tcga/defaults.py
@@ -23,6 +23,5 @@ VALID_ENDPOINTS = ['files', 'projects', 'cases', 'annotations']
 # number of records per page, by default
 DEFAULT_SIZE = 50
 # fields to pull for 'file-metadata' table
-DEFAULT_FILE_FIELDS=['file_id','file_name','cases.submitter_id','cases.case_id','data_category','data_type','cases.samples.tumor_descriptor','cases.samples.tissue_type','cases.samples.sample_type','cases.samples.submitter_id','cases.samples.sample_id',
-					'analysis.analysis_id', 'files.analysis.workflow_type']
+DEFAULT_FILE_FIELDS=['file_id','file_name','cases.submitter_id','cases.case_id','data_category','data_type','cases.samples.tumor_descriptor','cases.samples.tissue_type','cases.samples.sample_type','cases.samples.submitter_id','cases.samples.sample_id', 'analysis.analysis_id', 'files.analysis.workflow_type']
 DEFAULT_CHUNK_SIZE=30

--- a/query_tcga/defaults.py
+++ b/query_tcga/defaults.py
@@ -21,7 +21,7 @@ VALID_CATEGORIES = [
 # these are used since you cannot query them
 VALID_ENDPOINTS = ['files', 'projects', 'cases', 'annotations']
 # number of records per page, by default
-DEFAULT_SIZE = 500
+DEFAULT_SIZE = 50
 # fields to pull for 'file-metadata' table
 DEFAULT_FILE_FIELDS=['file_id','file_name','cases.submitter_id','cases.case_id','data_category','data_type','cases.samples.tumor_descriptor','cases.samples.tissue_type','cases.samples.sample_type','cases.samples.submitter_id','cases.samples.sample_id',
 					'analysis.analysis_id', 'files.analysis.workflow_type']

--- a/query_tcga/defaults.py
+++ b/query_tcga/defaults.py
@@ -1,5 +1,5 @@
 # whether to use requests-cache 
-USE_CACHE = False
+USE_CACHE = True
 ## location of token authorizing download
 GDC_TOKEN_PATH = '/Users/jacquelineburos/Downloads/gdc-user-token.2016-09-12T16-39-34-04-00.txt'
 ## path to gdc-client

--- a/query_tcga/defaults.py
+++ b/query_tcga/defaults.py
@@ -21,7 +21,7 @@ VALID_CATEGORIES = [
 # these are used since you cannot query them
 VALID_ENDPOINTS = ['files', 'projects', 'cases', 'annotations']
 # number of records per page, by default
-DEFAULT_SIZE = 50
+DEFAULT_SIZE = 10
 # fields to pull for 'file-metadata' table
 DEFAULT_FILE_FIELDS=['file_id','file_name','cases.submitter_id','cases.case_id','data_category','data_type','cases.samples.tumor_descriptor','cases.samples.tissue_type','cases.samples.sample_type','cases.samples.submitter_id','cases.samples.sample_id', 'analysis.analysis_id', 'files.analysis.workflow_type']
 DEFAULT_CHUNK_SIZE=30

--- a/query_tcga/query_tcga.py
+++ b/query_tcga/query_tcga.py
@@ -15,7 +15,7 @@ cur_version = sys.version_info
 if cur_version <= py27_version:
     sys.path.append('~/projects/tcga-blca/query_tcga')
     from log_with import log_with
-    from .configure import get_setting_value
+    from .config import get_setting_value
     import parameters as _params
     import cache
     from cache import requests_get
@@ -24,7 +24,7 @@ if cur_version <= py27_version:
     from super_list import L
 else:
     from .log_with import log_with
-    from .configure import get_setting_value 
+    from .config import get_setting_value 
     from . import parameters as _params
     from . import cache
     from .cache import requests_get

--- a/query_tcga/query_tcga.py
+++ b/query_tcga/query_tcga.py
@@ -7,30 +7,15 @@ import numpy as np
 import tempfile
 import bs4
 import logging
-import sys
 
-py27_version = (2,7)
-cur_version = sys.version_info
-
-if cur_version <= py27_version:
-    sys.path.append('~/projects/tcga-blca/query_tcga')
-    from log_with import log_with
-    from .config import get_setting_value
-    import parameters as _params
-    import cache
-    from cache import requests_get
-    import helpers # import _compute_start_given_page, _convert
-    import api
-    from super_list import L
-else:
-    from .log_with import log_with
-    from .config import get_setting_value 
-    from . import parameters as _params
-    from . import cache
-    from .cache import requests_get
-    from . import helpers # import _compute_start_given_page, _convert
-    from . import api
-    from .super_list import L
+from .log_with import log_with
+from .config import get_setting_value 
+from . import parameters as _params
+from . import cache
+from .cache import requests_get
+from . import helpers # import _compute_start_given_page, _convert
+from . import api
+from .super_list import L
 
 ## cache recquets depending on value of 
 cache.setup_cache()

--- a/query_tcga/query_tcga.py
+++ b/query_tcga/query_tcga.py
@@ -15,7 +15,7 @@ cur_version = sys.version_info
 if cur_version <= py27_version:
     sys.path.append('~/projects/tcga-blca/query_tcga')
     from log_with import log_with
-    from .configure import get_setting_value 
+    from .configure import get_setting_value
     import parameters as _params
     import cache
     from cache import requests_get

--- a/query_tcga/query_tcga.py
+++ b/query_tcga/query_tcga.py
@@ -465,12 +465,13 @@ def get_clinical_data_from_file(xml_file, fileinfo=None, **kwargs):
     data['_source_type'] = 'XML'
     data['_source_desc'] = xml_file
     data['patient_id'] = soup.findChild('patient_id').text
+    #data['submitter_id'] = soup.findChild('submitter_id').text
     data['_source_file_uuid'] = file_id
-    ## get file meta-data (for case_id):
+    ## get file meta-data (for case_id & submitter_id):
     if fileinfo is not None:
-        data['case_id'] = fileinfo.loc[fileinfo['file_id']==file_id[0], 'case_id'].values[0]
-    else:
-        data['case_id'] = api.get_fileinfo_data(file_id=file_id)['case_id'][0]
+        fileinfo = api.get_fileinfo_data(file_id=file_id)['case_id'][0]
+    data['case_id'] = fileinfo.loc[fileinfo['file_id']==file_id[0], 'case_id'].values[0]
+    data['submitter_id'] = fileinfo.loc[fileinfo['file_id']==file_id[0], 'submitter_id'].values[0]
     return data
 
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -55,6 +55,7 @@ def test_get_fileinfo_data_multiple_files():
     assert isinstance(res, pd.DataFrame)
     assert len(res.index)==2
 
+
 def test_get_fileinfo_data_file_details():
     clin = qt.get_clinical_data(project_name=TEST_PROJECT, data_dir=TEST_DATA_DIR, n=1)
     res = api.get_fileinfo_data(file_id = clin['_source_file_uuid'][0])

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,11 +1,20 @@
 from query_tcga import api
 from query_tcga import query_tcga as qt
+from query_tcga import config
 import pandas as pd
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
 
 TEST_SAMPLE_FILE_ID='0001801b-54b0-4551-8d7a-d66fb59429bf'
 TEST_PROJECT='TCGA-BLCA'
-TEST_DATA_DIR='tests/test_data'
 TEST_CLIN_FILE_ID='6082fbb4-1f13-4e58-a0fb-33574354b74b'
+
+TEST_DATA_DIR='test/test_data'
+config.set_value(
+     GDC_DATA_DIR=TEST_DATA_DIR,
+     GDC_TOKEN_PATH='/Users/jacquelineburos/Downloads/gdc-user-token.2016-09-26T12-23-27-04-00.txt'
+     )
 
 
 def test_get_data_sample_file():
@@ -16,7 +25,7 @@ def test_get_data_sample_file():
 def test_get_data_sample_file_with_fields():
     res = api.get_data(endpoint_name='files',
                         query_args={'files.file_id': TEST_SAMPLE_FILE_ID},
-                        fields=api.defaults.DEFAULT_FILE_FIELDS,
+                        fields=config.get_setting_value('DEFAULT_FILE_FIELDS'),
                         )
     assert len(res.json()['data']['hits']) == 1
 
@@ -24,7 +33,7 @@ def test_get_data_sample_file_with_fields():
 def test_get_data_clin_file_with_fields():
     res = api.get_data(endpoint_name='files',
                         query_args={'files.file_id': TEST_CLIN_FILE_ID},
-                        fields=api.defaults.DEFAULT_FILE_FIELDS,
+                        fields=config.get_setting_value('DEFAULT_FILE_FIELDS'),
                         )
     assert len(res.json()['data']['hits']) == 1
 

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -1,8 +1,11 @@
 from query_tcga import parameters
-from query_tcga import helpers
+from query_tcga import helpers, config
 import pytest
 import shutil
 import pandas as pd
+
+TEST_DATA_DIR='test/test_data'
+config.set_value(GDC_DATA_DIR=TEST_DATA_DIR, GDC_TOKEN_PATH='/Users/jacquelineburos/Downloads/gdc-user-token.2016-09-26T12-23-27-04-00.txt')
 
 
 def test_construct_filter_parameters():

--- a/test/test_query_tcga.py
+++ b/test/test_query_tcga.py
@@ -1,5 +1,6 @@
 
 from query_tcga import query_tcga as qt
+from query_tcga import config
 import pytest
 import shutil
 import pandas as pd
@@ -9,11 +10,12 @@ from query_tcga.log_with import log_with
 import logging
 
 
+TEST_DATA_DIR='test/test_data'
+config.set_value(GDC_DATA_DIR=TEST_DATA_DIR, GDC_TOKEN_PATH='/Users/jacquelineburos/Downloads/gdc-user-token.2016-09-26T12-23-27-04-00.txt')
+
 logging.basicConfig()
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-
-DATA_DIR = 'tests/test_data'
 
 manifest = pytest.mark.NAME
 
@@ -68,9 +70,9 @@ def test_get_manifest_using_n():
 @log_with()
 @manifest
 def test_download_files_using_page():
-    _rmdir_if_exists(DATA_DIR)
+    _rmdir_if_exists(TEST_DATA_DIR)
     res = qt.download_files(project_name='TCGA-BLCA', data_category='Clinical',
-         pages=1, size=5, data_dir=DATA_DIR)
+         pages=1, size=5, data_dir=TEST_DATA_DIR)
     assert isinstance(res, list)
     assert len(res) == 5
 
@@ -78,7 +80,7 @@ def test_download_files_using_page():
 @manifest
 def test_download_files_using_n():
     res = qt.download_files(project_name='TCGA-BLCA', data_category='Clinical',
-         n=5, data_dir=DATA_DIR)
+         n=5, data_dir=TEST_DATA_DIR)
     assert isinstance(res, list)
     assert len(res) == 5
 
@@ -91,15 +93,15 @@ def _rmdir_if_exists(*args, **kwargs):
 
 @manifest
 def test_download_clinical_files():
-    _rmdir_if_exists(DATA_DIR)
-    res = qt.download_clinical_files(project_name='TCGA-BLCA', n=5, data_dir=DATA_DIR)
+    _rmdir_if_exists(TEST_DATA_DIR)
+    res = qt.download_clinical_files(project_name='TCGA-BLCA', n=5, data_dir=TEST_DATA_DIR)
     assert isinstance(res, list)
     assert len(res) == 5
 
 
 @manifest
 def test_get_clinical_data():
-    res = qt.get_clinical_data(project_name='TCGA-BLCA', n=5, data_dir=DATA_DIR)
+    res = qt.get_clinical_data(project_name='TCGA-BLCA', n=5, data_dir=TEST_DATA_DIR)
     assert isinstance(res, pd.DataFrame)
     assert len(res.index) == 5
     assert '_source_type' in res.columns
@@ -111,17 +113,17 @@ def test_get_clinical_data():
 def test_list_failed_downloads():
     _rmdir_if_exists(DATA_DIR)
     manifest_contents = qt.get_manifest(project_name='TCGA-BLCA', data_category='Clinical', n=5)
-    failed = qt._list_failed_downloads(manifest_contents=manifest_contents, data_dir=DATA_DIR)
+    failed = qt._list_failed_downloads(manifest_contents=manifest_contents, data_dir=TEST_DATA_DIR)
     assert len(failed) == 5
-    qt.download_clinical_files(project_name='TCGA-BLCA', n=5, data_dir=DATA_DIR)
-    new_failed = qt._list_failed_downloads(manifest_contents=manifest_contents, data_dir=DATA_DIR)
+    qt.download_clinical_files(project_name='TCGA-BLCA', n=5, data_dir=TEST_DATA_DIR)
+    new_failed = qt._list_failed_downloads(manifest_contents=manifest_contents, data_dir=TEST_DATA_DIR)
     assert isinstance(new_failed, list)
     assert len(new_failed) == 0
 
 
 def test_download_from_manifest():
     manifest_contents = qt.get_manifest(project_name='TCGA-BLCA', data_category='Clinical', n=5)
-    downloaded = qt.download_from_manifest(manifest_contents=manifest_contents, data_dir=DATA_DIR)
+    downloaded = qt.download_from_manifest(manifest_contents=manifest_contents, data_dir=TEST_DATA_DIR)
     assert isinstance(downloaded, list)
     assert len(manifest_contents.splitlines()) == len(downloaded)+1
 


### PR DESCRIPTION
A few updates:
1. Pull out default values into a separate `config` object.
    - Allow users to update configs manually or by loading a config file
2. Modify caching strategy to use  requests-cache, and to increase the timeout
3. Improve logging & handing of dropped queries
4. Add submitter_id to clinical data
5. Reduce redundant querying to fileinfo by passing this data around
